### PR TITLE
fix: Refactor condition to check for cluster in kind

### DIFF
--- a/app/services/k8s.py
+++ b/app/services/k8s.py
@@ -251,7 +251,7 @@ async def check_should_enroll(vm_object, namespace):
             api = client.CustomObjectsApi(api_client)
 
             raw_obj = None
-            if it_kind == "VirtualMachineClusterInstanceType":
+            if "cluster" in it_kind.lower():
                 raw_obj = await api.get_cluster_custom_object(
                     group="instancetype.kubevirt.io",
                     version="v1beta1",


### PR DESCRIPTION
Refactored an if statement so when the clusterinstancetype gets looked up it doesn't matter how its spelt in terms of capital letters as long as cluster is in the kind it will work