### PR TITLE
feat: reliability, observability, and code quality improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`virt-ipa-joiner` is a Kubernetes/OpenShift mutating webhook + lifecycle controller that automatically enrolls KubeVirt `VirtualMachine` objects into FreeIPA (or Red Hat IDM). It runs as a single container with two concurrent components.
+
+> **Note:** `main.py` at the repo root is an older prototype. The active application lives entirely under `app/`.
+
+## Development Setup
+
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt -r requirements-test.txt -r requirements-dev.txt
+pre-commit install --install-hooks
+```
+
+## Common Commands
+
+```bash
+# Run the app locally (requires env vars — see README)
+uvicorn app.main:app --reload --port 8080
+
+# Lint
+ruff check .
+ruff format --check .
+
+# Run all tests
+PYTHONPATH=. pytest -v
+
+# Run a single test file
+PYTHONPATH=. pytest -v app/tests/test_workers.py
+
+# Build container
+podman build -t virt-ipa-joiner:latest -f Containerfile .
+```
+
+Commits must follow the **Conventional Commits** spec (`feat:`, `fix:`, etc.) — enforced by a pre-commit hook.
+
+## Architecture
+
+### Two concurrent components in one process
+
+`app/main.py` starts FastAPI and spawns `run_controller()` as a background asyncio task via the `lifespan` context manager.
+
+**1. Mutating Webhook** (`app/routers/webhook.py` → `POST /mutate`)
+
+- Receives Kubernetes `AdmissionReview` requests for `VirtualMachine` creation.
+- Calls `check_should_enroll()` — a VM is enrolled if it has label `ipa-enroll: "true"`, or if its referenced `VirtualMachineClusterInstanceType` has that label (inheritance check requires a K8s API call).
+- On enroll: calls `ipa_host_add()` to pre-create the host in FreeIPA using the admission UID as the OTP, then builds a JSON Patch that injects a `cloudinitdisk` volume with a `cloud-config` running `ipa-client-install`, adds a Kubernetes finalizer, and sets status annotations.
+- Always returns `allowed: true` (soft-fail) so VM creation is never blocked even if IPA enrollment fails.
+- Rejects VMs whose generated FQDN exceeds 64 characters (hard rejection).
+- Background tasks fire after the webhook response: `send_delayed_creation_event` and `poll_ipa_keytab`.
+
+**2. Lifecycle Controller** (`app/services/k8s.py` → `run_controller()`)
+
+- Watches all `kubevirt.io/v1 virtualmachines` cluster-wide using `kubernetes_asyncio` watch streams with a 60-second timeout, restarting on any error.
+- On deletion: detects `deletionTimestamp` + presence of the finalizer, calls `ipa_host_del()`, emits a K8s event, then patches out the finalizer to unblock K8s deletion.
+- Idempotency: checks for an existing `IPADeleteSuccess` event before acting (prevents double-deletion on reconnect).
+
+### Key service modules
+
+| File | Responsibility |
+|------|---------------|
+| `app/config.py` | Layered config: defaults → `config.yaml` (lowercase keys) → env vars (uppercase). Exports `CONFIG` dict and `logger`. |
+| `app/services/ipa.py` | FreeIPA client: DNS SRV discovery (`_kerberos._tcp.<DOMAIN>`), connection retry loop across multiple servers, `ipa_host_add` / `ipa_host_del`, FQDN builder. |
+| `app/services/k8s.py` | Controller loop, keytab poller (`poll_ipa_keytab`, 15-minute timeout, 10-second intervals), K8s event emitter, finalizer removal, `check_should_enroll`. |
+
+### Configuration precedence
+
+`config.yaml` (lowercase keys like `ipa_host`) → overridden by env vars (`IPA_HOST`, `IPA_PASS`, `DOMAIN`, `REALM`, `LOG_LEVEL`, `FINALIZER_NAME`, `IPA_VERIFY_SSL`). `OS_MAP` in config.yaml is merged (not replaced) with defaults.
+
+### OS detection for cloud-init
+
+The `OS_MAP` config key maps OS name fragments (e.g. `ubuntu`, `debian`, `rhel`) to the package install command. The webhook inspects `spec.preference.name` of the VM and matches against these keys to pick the right install command. Default is `dnf install -y ipa-client`.
+
+### FQDN format
+
+`{vm_name}.{namespace}.{DOMAIN}` — must be ≤ 64 characters.
+
+## Testing
+
+Tests live in `app/tests/`. `conftest.py` patches `kubernetes_asyncio` and `python_freeipa` into `sys.modules` before any app code is imported — this is required because those libraries are not available in the test environment without system dependencies (openldap, cyrus-sasl). Always set `PYTHONPATH=.` when running pytest locally.
+
+## Deployment
+
+Deploy via Kustomize overlays under `docs/deploy/kustomize/`. The overlay at `overlays/cluster1/` contains the cluster-specific `Secret` with IPA credentials. The app runs in the `openshift-cnv` namespace as UID 1001 on Red Hat UBI 9.
+
+## Releasing
+
+Bump the version in the `VERSION` file, open a PR, and merge to `main`. The CI pipeline detects the new version tag and pushes the image to GHCR with `latest` and the version tag. Do not push the tag manually.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The application consists of two main components running in a single container:
 1. **Mutating Webhook (FastAPI):** Intercepts `VirtualMachine` creation requests. It pre-creates the host in FreeIPA, generates an OTP, and injects a `cloud-init` script into the VM to install the IPA client automatically on first boot.
 2. **Lifecycle Controller (AsyncIO):** Watches for VM deletion events to remove the host from FreeIPA. It also polls newly created VMs to verify that the enrollment was successful (checking for Keytab existence).
 
+The application also exposes `/healthz` (liveness), `/readyz` (readiness — additionally checks IPA reachability), and `/metrics` (Prometheus) on the same HTTPS port.
+
 ## 🔄 Order of Events
 
 ### Phase 1: VM Creation & Enrollment
@@ -35,7 +37,7 @@ The application consists of two main components running in a single container:
 * **Dynamic OS Support:** Automatically detects OS (RHEL/CentOS/Fedora vs Ubuntu/Debian) based on `instancetype` or `preference` and adjusts install commands (`dnf` vs `apt-get`).
 * **InstanceType Inheritance:** Supports inheriting enrollment labels from `VirtualMachineClusterInstanceType`.
 * **Security:** Runs as a non-root user (UID 1001) on Red Hat UBI 9.
-* **Observability:** Emits native Kubernetes Events (`Normal` and `Warning`) to the VM object for enrollment status.
+* **Observability:** Emits native Kubernetes Events (`Normal` and `Warning`) to the VM object for enrollment status. Exposes a Prometheus `/metrics` endpoint (HTTP request counts, latency, and sizes) and separate `/healthz` (liveness) and `/readyz` (readiness) probes.
 
 ## 🚀 Deployment
 

--- a/app/health.py
+++ b/app/health.py
@@ -1,0 +1,17 @@
+"""
+Centralized health state.
+
+Flags are updated by service calls (get_ipa_client); probe endpoints
+read them without making any external API calls.
+"""
+
+_ipa_healthy: bool = True
+
+
+def set_ipa_healthy(value: bool) -> None:
+    global _ipa_healthy
+    _ipa_healthy = value
+
+
+def is_ipa_healthy() -> bool:
+    return _ipa_healthy

--- a/app/main.py
+++ b/app/main.py
@@ -1,41 +1,63 @@
 import asyncio
 import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from prometheus_fastapi_instrumentator import Instrumentator
+
 from app.routers import webhook
 from app.services.k8s import run_controller
 from app.config import logger
+from app.task_tracker import cancel_all_tasks
+from app.health import is_ipa_healthy
+
+# Holds the controller task so probes can inspect its state.
+_controller_task: asyncio.Task | None = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    global _controller_task
     version = os.getenv("APP_VERSION", "unknown")
     logger.info(f"Starting virt-ipa-joiner controller version: {version}")
 
-    # Start the background controller
-    controller_task = asyncio.create_task(run_controller())
+    _controller_task = asyncio.create_task(run_controller())
 
-    yield  # Application runs here
+    yield
 
-    # Shutdown logic
+    # --- Shutdown ---
     logger.info("Shutting down virt-ipa-joiner...")
-    controller_task.cancel()
+    _controller_task.cancel()
     try:
-        await controller_task
+        await _controller_task
     except asyncio.CancelledError:
         pass
+
+    # Cancel any in-flight keytab pollers / delayed event senders.
+    await cancel_all_tasks()
 
 
 app = FastAPI(lifespan=lifespan)
 
+# Expose /metrics for Prometheus scraping.
+Instrumentator().instrument(app).expose(app)
+
 
 @app.get("/healthz")
 async def healthz():
-    """
-    Simple health check for Kubernetes Liveness/Readiness probes.
-    """
+    """Liveness probe — fails if the controller task has exited unexpectedly."""
+    if _controller_task is None or _controller_task.done():
+        raise HTTPException(status_code=503, detail="controller task has exited")
     return {"status": "ok"}
 
 
-# Register the router
+@app.get("/readyz")
+async def readyz():
+    """Readiness probe — fails if the controller is not running or IPA is unreachable."""
+    if _controller_task is None or _controller_task.done():
+        raise HTTPException(status_code=503, detail="controller not running")
+    if not is_ipa_healthy():
+        raise HTTPException(status_code=503, detail="IPA is unreachable")
+    return {"status": "ready"}
+
+
 app.include_router(webhook.router)

--- a/app/routers/webhook.py
+++ b/app/routers/webhook.py
@@ -2,8 +2,9 @@ import base64
 import jsonpatch
 import yaml
 from typing import Dict, Any
-from fastapi import APIRouter, Body, BackgroundTasks
+from fastapi import APIRouter, Body
 from app.config import CONFIG, logger
+from app.task_tracker import create_tracked_task
 from app.services.k8s import (
     check_should_enroll,
     send_delayed_creation_event,
@@ -15,9 +16,7 @@ router = APIRouter()
 
 
 @router.post("/mutate")
-async def mutate_vm(
-    background_tasks: BackgroundTasks, review: Dict[str, Any] = Body(...)
-):
+async def mutate_vm(review: Dict[str, Any] = Body(...)):
     request = review.get("request")
     if not request:
         return {
@@ -99,28 +98,30 @@ async def mutate_vm(
         status_msg = f"Enrolled as {fqdn}"
 
         # Send "Started" Event
-        background_tasks.add_task(
-            send_delayed_creation_event,
-            namespace,
-            vm_name,
-            "IPAEnrollSuccess",
-            f"Successfully pre-created host {fqdn} in IPA",
-            "Normal",
+        create_tracked_task(
+            send_delayed_creation_event(
+                namespace,
+                vm_name,
+                "IPAEnrollSuccess",
+                f"Successfully pre-created host {fqdn} in IPA",
+                "Normal",
+            )
         )
 
         # Start "Finished" Watcher (Keytab Polling)
-        background_tasks.add_task(poll_ipa_keytab, namespace, vm_name, fqdn)
+        create_tracked_task(poll_ipa_keytab(namespace, vm_name, fqdn))
 
     except Exception as e:
         enrollment_success = False
         status_msg = f"Failed: {str(e)}"
-        background_tasks.add_task(
-            send_delayed_creation_event,
-            namespace,
-            vm_name,
-            "IPAEnrollFailed",
-            f"Failed to pre-create host in IPA: {str(e)}",
-            "Warning",
+        create_tracked_task(
+            send_delayed_creation_event(
+                namespace,
+                vm_name,
+                "IPAEnrollFailed",
+                f"Failed to pre-create host in IPA: {str(e)}",
+                "Warning",
+            )
         )
 
     if enrollment_success:
@@ -146,7 +147,7 @@ async def mutate_vm(
                 install_cmd_str = os_cmd
                 break
 
-        realm_arg = CONFIG.get("REALM", CONFIG["DOMAIN"].upper())
+        realm_arg = CONFIG.get("REALM") or CONFIG["DOMAIN"].upper()
 
         ipa_cmd_parts = [
             "ipa-client-install",

--- a/app/services/ipa.py
+++ b/app/services/ipa.py
@@ -1,5 +1,6 @@
 from python_freeipa import Client
 from app.config import CONFIG, logger
+from app.health import set_ipa_healthy
 from typing import List, Tuple, Any
 import datetime
 import random
@@ -102,13 +103,11 @@ def get_ipa_client() -> Tuple[Any, str]:
         try:
             logger.debug(f"Attempting connection to FreeIPA server: {host}")
 
-            # Initialize Client
             c = Client(host=host, verify_ssl=CONFIG["IPA_VERIFY_SSL"])
             c.login(CONFIG["IPA_USER"], CONFIG["IPA_PASS"])
 
             logger.info(f"Successfully authenticated to {host}")
-
-            # Return BOTH the client and the hostname string we connected to
+            set_ipa_healthy(True)
             return c, host
 
         except Exception as e:
@@ -116,15 +115,15 @@ def get_ipa_client() -> Tuple[Any, str]:
             errors.append(f"{host}: {str(e)}")
             continue  # Try the next server
 
-    # If loop finishes without returning, we failed everywhere
+    # All candidates failed.
+    set_ipa_healthy(False)
     raise RuntimeError(f"All IPA connection attempts failed. Errors: {errors}")
 
 
 # --- Helper: Robust Command Executor ---
 def execute_ipa_command(client, command, *args, **kwargs):
+    """Execute an IPA command, falling back to direct JSON-RPC on AttributeError."""
     try:
-        if hasattr(client, command):
-            return getattr(client, command)(*args, **kwargs)
         return getattr(client, command)(*args, **kwargs)
     except AttributeError:
         return client._request(command, list(args), kwargs)
@@ -145,11 +144,21 @@ def ipa_host_add(vm_name: str, namespace: str, vm_uuid: str) -> Tuple[str, str]:
             client_ipa, "host_add", fqdn, force=True, description=desc_text
         )
     except Exception as e:
+        # Idempotency: treat a duplicate-entry error as a non-fatal warning.
+        # This happens when K8s retries an admission request for the same VM.
         if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
-            logger.warning(f"Host {fqdn} already exists in IPA — overwriting OTP.")
+            result = execute_ipa_command(client_ipa, "host_show", fqdn)
+            host_data = result.get("result", {}) if isinstance(result, dict) else {}
+            if host_data.get("has_keytab"):
+                raise RuntimeError(
+                    f"Host {fqdn} is already enrolled in IPA (keytab present). "
+                    "Delete the existing IPA host entry before re-registering."
+                ) from e
+            logger.warning(
+                f"Host {fqdn} pre-registered but not enrolled — overwriting OTP."
+            )
         else:
-            logger.error(f"IPA Add Error for {fqdn}: {e}")
-            raise e
+            raise
 
     otp = vm_uuid
     execute_ipa_command(client_ipa, "host_mod", fqdn, userpassword=otp)

--- a/app/services/k8s.py
+++ b/app/services/k8s.py
@@ -3,11 +3,24 @@ import datetime
 from typing import Dict, Any, cast
 from kubernetes_asyncio import client, config, watch
 
-# Import shared config
 from app.config import CONFIG, logger
-
-# Import IPA actions needed for the polling/deletion logic
 from app.services.ipa import ipa_host_del, get_ipa_client, execute_ipa_command
+
+# ---------------------------------------------------------------------------
+# K8s config — loaded once, reused everywhere.
+# ---------------------------------------------------------------------------
+_k8s_config_loaded = False
+
+
+async def _ensure_k8s_config() -> None:
+    global _k8s_config_loaded
+    if _k8s_config_loaded:
+        return
+    try:
+        config.load_incluster_config()
+    except Exception:
+        await config.load_kube_config()
+    _k8s_config_loaded = True
 
 
 # --- HELPER: K8s Event Sender ---
@@ -21,10 +34,7 @@ async def send_k8s_event(
     api_version="kubevirt.io/v1",
 ):
     try:
-        try:
-            config.load_incluster_config()
-        except Exception:
-            await config.load_kube_config()
+        await _ensure_k8s_config()
 
         async with client.ApiClient() as api_client:
             core_api = client.CoreV1Api(api_client)
@@ -53,7 +63,6 @@ async def send_k8s_event(
                 "count": 1,
             }
 
-            # type: ignore prevents Pylance from flagging the coroutine as not awaitable
             await core_api.create_namespaced_event(namespace, event)  # type: ignore
 
     except Exception as e:
@@ -65,21 +74,21 @@ async def send_delayed_creation_event(
     namespace, name, reason, message, event_type="Normal"
 ):
     """
-    Polls K8s until the VM is found (persisted), then sends the event linked to its real UID.
+    Polls K8s until the VM is found (persisted), then sends the event linked
+    to its real UID. Uses exponential backoff (2 → 30 s, max 10 attempts).
     """
     logger.info(f"Background task: Waiting for creation of {name} to attach event...")
-    for attempt in range(5):
-        await asyncio.sleep(2)
-        try:
-            try:
-                config.load_incluster_config()
-            except Exception:
-                await config.load_kube_config()
+    await _ensure_k8s_config()
 
+    delay = 2
+    for attempt in range(10):
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 30)
+
+        try:
             async with client.ApiClient() as api_client:
                 cust_api = client.CustomObjectsApi(api_client)
                 try:
-                    # type: ignore fixes Pylance "not awaitable" error
                     raw_vm = await cust_api.get_namespaced_custom_object(
                         group="kubevirt.io",
                         version="v1",
@@ -122,12 +131,13 @@ async def send_delayed_creation_event(
             logger.error(f"Error in delayed event loop for {name}: {e}")
 
     logger.warning(
-        f"Gave up waiting for VM {name} to appear after 10 seconds. Event '{reason}' was dropped."
+        f"Gave up waiting for VM {name} after 10 attempts. Event '{reason}' was dropped."
     )
 
 
 # --- HELPER: Check Existing Event ---
 async def event_already_exists(namespace, uid, reason):
+    await _ensure_k8s_config()
     try:
         async with client.ApiClient() as api_client:
             core_api = client.CoreV1Api(api_client)
@@ -170,7 +180,6 @@ async def poll_ipa_keytab(namespace, name, fqdn, timeout_minutes=15):
     end_time = datetime.datetime.now() + datetime.timedelta(minutes=timeout_minutes)
 
     try:
-        # UPDATED: Unpack the tuple (client, hostname)
         c, _ = get_ipa_client()
     except Exception as e:
         logger.error(f"Failed to create IPA client for polling: {e}")
@@ -201,7 +210,6 @@ async def poll_ipa_keytab(namespace, name, fqdn, timeout_minutes=15):
                     return
 
         except Exception as e:
-            # UPDATED: Log as warning so we see the root cause (e.g. "auth failed")
             logger.warning(f"Polling check failed for {fqdn}: {e}")
             try:
                 logger.info("Attempting to switch/reconnect IPA client...")
@@ -242,10 +250,7 @@ async def check_should_enroll(vm_object, namespace):
     logger.info(f"Checking InstanceType {it_name} ({it_kind}) for inheritance...")
 
     try:
-        try:
-            config.load_incluster_config()
-        except Exception:
-            await config.load_kube_config()
+        await _ensure_k8s_config()
 
         async with client.ApiClient() as api_client:
             api = client.CustomObjectsApi(api_client)
@@ -287,11 +292,9 @@ async def check_should_enroll(vm_object, namespace):
 # --- MAIN CONTROLLER LOOP ---
 async def run_controller():
     logger.info("Starting Controller Watcher...")
-    try:
-        config.load_incluster_config()
-    except Exception:
-        await config.load_kube_config()
+    await _ensure_k8s_config()
 
+    backoff = 5
     while True:
         try:
             async with client.ApiClient() as api_client:
@@ -337,7 +340,6 @@ async def run_controller():
 
                         logger.info(f"Processing deletion for {name}.{ns}...")
                         try:
-                            # Calls IPA service to delete
                             ipa_host_del(name, ns)
                             await send_k8s_event(
                                 ns,
@@ -364,6 +366,10 @@ async def run_controller():
                                     api_version=obj_api_version,
                                 )
 
+            # Clean stream exit (60 s timeout) — reset backoff.
+            backoff = 5
+
         except Exception as e:
-            logger.error(f"Watcher stream error: {e}. Restarting...")
-            await asyncio.sleep(5)
+            logger.error(f"Watcher stream error: {e}. Restarting in {backoff}s...")
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60)

--- a/app/task_tracker.py
+++ b/app/task_tracker.py
@@ -1,0 +1,26 @@
+"""
+Tracks long-running background asyncio tasks so they can be cancelled
+cleanly on application shutdown.
+"""
+
+import asyncio
+from typing import Set
+
+_background_tasks: Set[asyncio.Task] = set()
+
+
+def create_tracked_task(coro) -> asyncio.Task:
+    """Schedule a coroutine as a tracked asyncio task."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+async def cancel_all_tasks() -> None:
+    """Cancel all tracked tasks and wait for them to finish."""
+    tasks = list(_background_tasks)
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -22,9 +22,12 @@ sys.modules["python_freeipa"] = MagicMock()
 
 @pytest.fixture
 def mock_ipa_client(mocker):
-    """Mocks the internal IPA client wrapper."""
+    """Mocks the internal IPA client wrapper. Returns the mock client object."""
     mock_client = MagicMock()
-    mocker.patch("app.services.ipa.get_ipa_client", return_value=mock_client)
+    mocker.patch(
+        "app.services.ipa.get_ipa_client",
+        return_value=(mock_client, "ipa.example.com"),
+    )
     return mock_client
 
 

--- a/app/tests/test_ipa.py
+++ b/app/tests/test_ipa.py
@@ -1,6 +1,7 @@
-from unittest.mock import MagicMock
+import pytest
+from unittest.mock import MagicMock, call
 import dns.resolver
-from app.services.ipa import ipa_resolve_srv, get_ipa_client
+from app.services.ipa import ipa_resolve_srv, get_ipa_client, ipa_host_add
 
 # --- Test DNS Resolution ---
 
@@ -89,8 +90,6 @@ def test_get_ipa_client_retry_flow(mocker):
     assert hostname == "static-backup"
 
     # Verify we tried initializing with both hosts in order
-    from unittest.mock import call
-
     expected_calls = [
         call(host="dns-host-1", verify_ssl=False),
         call().login("admin", "pass"),
@@ -98,3 +97,52 @@ def test_get_ipa_client_retry_flow(mocker):
         call().login("admin", "pass"),
     ]
     MockClient.assert_has_calls(expected_calls, any_order=False)
+
+
+# --- Test ipa_host_add idempotency ---
+
+
+def _mock_ipa_env(mocker):
+    """Patch config and get_ipa_client for ipa_host_add unit tests."""
+    mocker.patch.dict(
+        "app.services.ipa.CONFIG",
+        {"DOMAIN": "example.com", "IPA_USER": "admin", "IPA_PASS": "pass"},
+    )
+    mock_client = MagicMock()
+    mocker.patch(
+        "app.services.ipa.get_ipa_client", return_value=(mock_client, "ipa.example.com")
+    )
+    return mock_client
+
+
+def test_host_add_idempotent_overwrites_otp_when_not_enrolled(mocker):
+    """Duplicate entry with has_keytab=False should silently overwrite the OTP."""
+    mock_client = _mock_ipa_env(mocker)
+
+    duplicate_err = Exception(
+        'host with name "my-vm.default.example.com" already exists'
+    )
+    # host_add has no direct method → falls through to _request → raises duplicate
+    mock_client.host_add = MagicMock(side_effect=AttributeError)
+    mock_client._request.side_effect = [duplicate_err]
+    # host_show and host_mod go through getattr directly on the MagicMock
+    mock_client.host_show.return_value = {"result": {"has_keytab": False}}
+
+    otp, server = ipa_host_add("my-vm", "default", "test-uuid-1234")
+    assert otp == "test-uuid-1234"
+    assert server == "ipa.example.com"
+
+
+def test_host_add_raises_when_host_already_enrolled(mocker):
+    """Duplicate entry with has_keytab=True must raise RuntimeError."""
+    mock_client = _mock_ipa_env(mocker)
+
+    duplicate_err = Exception(
+        'host with name "my-vm.default.example.com" already exists'
+    )
+    mock_client.host_add = MagicMock(side_effect=AttributeError)
+    mock_client._request.side_effect = [duplicate_err]
+    mock_client.host_show.return_value = {"result": {"has_keytab": True}}
+
+    with pytest.raises(RuntimeError, match="already enrolled"):
+        ipa_host_add("my-vm", "default", "test-uuid-5678")

--- a/app/tests/test_webhook.py
+++ b/app/tests/test_webhook.py
@@ -78,8 +78,8 @@ async def test_mutate_vm_success(mocker):
     # Mock K8s checks (Always say yes to enrollment)
     mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
 
-    # Mock Background Tasks (so we don't actually spawn threads)
-    mocker.patch("fastapi.BackgroundTasks.add_task")
+    # Prevent background tasks from actually being scheduled.
+    mocker.patch("app.routers.webhook.create_tracked_task")
 
     # 2. Make the Request
     response = client.post("/mutate", json=SAMPLE_REVIEW)
@@ -207,3 +207,41 @@ def test_cloud_init_syntax_validity(mocker):
     # Verify structure
     assert "runcmd" in parsed
     assert isinstance(parsed["runcmd"], list)
+
+
+def test_mutate_vm_realm_fallback(mocker):
+    """
+    Verifies that when REALM is not configured (None), ipa-client-install
+    receives --realm=<DOMAIN.upper()> rather than --realm=None.
+    """
+    mocker.patch(
+        "app.routers.webhook.ipa_host_add",
+        return_value=("otp-realm-test", "ipa-server.example.com"),
+    )
+    mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
+    mocker.patch("app.routers.webhook.create_tracked_task")
+
+    # Simulate the default state: REALM not set, DOMAIN = "example.com"
+    mocker.patch.dict(
+        "app.routers.webhook.CONFIG",
+        {"REALM": None, "DOMAIN": "example.com"},
+    )
+
+    response = client.post("/mutate", json=SAMPLE_REVIEW)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["response"]["allowed"] is True
+
+    patch_decoded = base64.b64decode(data["response"]["patch"]).decode()
+    patch_obj = json.loads(patch_decoded)
+
+    volume_patch = next(
+        (op for op in patch_obj if "volumes" in op.get("path", "")), None
+    )
+    assert volume_patch is not None
+
+    user_data = volume_patch["value"]["cloudInitNoCloud"]["userData"]
+
+    # Must contain the uppercased domain, not the string "None".
+    assert "--realm=EXAMPLE.COM" in user_data
+    assert "--realm=None" not in user_data

--- a/app/tests/test_workers.py
+++ b/app/tests/test_workers.py
@@ -61,7 +61,7 @@ async def test_retry_logic_failure(mocker, mock_k8s_client):
 
     await send_delayed_creation_event("default", "ghost-vm", "Reason", "Msg")
 
-    assert mock_cust_api.get_namespaced_custom_object.call_count == 5
+    assert mock_cust_api.get_namespaced_custom_object.call_count == 10
     mock_send_event.assert_not_called()
 
 

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -41,10 +41,76 @@ This will create or update the necessary resources in the openshift-cnv namespac
 
 ## Verification
 
-And check that the associated pods are running:
+Check that the associated pods are running:
 
 ```bash
 oc get pods -n openshift-cnv
+```
+
+Verify the health endpoints directly from within the cluster (the app is HTTPS-only):
+
+```bash
+# Liveness — is the controller task running?
+curl -k https://<pod-ip>:8443/healthz
+
+# Readiness — is the controller running AND was IPA reachable on the last attempt?
+curl -k https://<pod-ip>:8443/readyz
+```
+
+Both return `{"status":"ok"}` / `{"status":"ready"}` on success, or HTTP 503 with a detail message on failure.
+
+## Health Probes
+
+The application exposes two distinct probe endpoints, both on HTTPS port 8443:
+
+| Endpoint | Probe type | Fails when |
+| :--- | :--- | :--- |
+| `/healthz` | Liveness | The background controller task has exited unexpectedly |
+| `/readyz` | Readiness | The controller is not running **or** IPA was unreachable on the last connection attempt |
+
+The Kustomize base wires these up automatically. The key distinction: if IPA goes temporarily offline, pods report not-ready (traffic stops routing to them) but are **not** restarted — they recover automatically once IPA comes back.
+
+## Observability
+
+The application exposes a Prometheus-compatible `/metrics` endpoint on the same HTTPS port (8443). It provides standard HTTP instrumentation for all routes:
+
+- `http_requests_total` — request count by method, route, and status code
+- `http_request_duration_seconds` — latency histogram
+- `http_request_size_bytes` / `http_response_size_bytes` — payload size histograms
+
+### Scraping with Prometheus Operator (OpenShift)
+
+The app uses the OpenShift serving cert (signed by the cluster CA), so a `ServiceMonitor` can scrape it without disabling TLS verification:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: virt-ipa-joiner
+  namespace: openshift-cnv
+spec:
+  selector:
+    matchLabels:
+      app: virt-ipa-joiner
+  endpoints:
+    - port: https        # must match the port name in the Service
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      interval: 30s
+      path: /metrics
+```
+
+> **Note:** For this to work, add a named port to the `Service` and ensure the OpenShift user-workload monitoring stack is enabled (`enableUserWorkload: true` in the `cluster-monitoring-config` ConfigMap).
+
+### Adding a named port to the Service
+
+```yaml
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
 ```
 
 ## Configuration options

--- a/docs/deploy/kustomize/base/deployment.yaml
+++ b/docs/deploy/kustomize/base/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             failureThreshold: 30
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 8443
               scheme: HTTPS
             initialDelaySeconds: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jsonpatch==1.33
 kubernetes_asyncio==33.3.0
 PyYAML==6.0.3
 dnspython==2.8.0
+prometheus-fastapi-instrumentator==7.1.0

--- a/tests/integration/test_ipa_lifecycle.py
+++ b/tests/integration/test_ipa_lifecycle.py
@@ -124,19 +124,44 @@ class TestIPAHostLifecycle:
         # Never added — delete should be a no-op
         ipa_host_del(vm_name, namespace)
 
-    def test_host_add_is_idempotent(self):
-        """Adding a host that already exists should succeed (overwrites OTP)."""
+    def test_host_add_is_idempotent_when_not_enrolled(self):
+        """Adding a host that exists but has no keytab should overwrite the OTP."""
         vm_name, namespace, vm_uuid = _unique_vm()
 
         ipa_host_add(vm_name, namespace, vm_uuid)
 
-        # Second add with a new UUID — should overwrite OTP, not raise
+        # Second add with a new UUID — not enrolled, so should overwrite OTP silently
         new_uuid = str(uuid.uuid4())
         otp, server = ipa_host_add(vm_name, namespace, new_uuid)
         assert otp == new_uuid
 
         # Cleanup
         ipa_host_del(vm_name, namespace)
+
+    def test_host_add_refuses_to_overwrite_enrolled_host(self):
+        """Adding a host that has already enrolled (keytab present) must raise."""
+        vm_name, namespace, vm_uuid = _unique_vm()
+        fqdn = build_fqdn(vm_name, namespace)
+
+        ipa_host_add(vm_name, namespace, vm_uuid)
+
+        # Simulate enrollment by setting has_keytab via host-mod on the IPA side
+        client, _ = get_ipa_client()
+        execute_ipa_command(client, "host_mod", fqdn, userpassword=None, random=True)
+        # Mark as having a keytab by provisioning one via getkeytab (simplest way
+        # to flip has_keytab=True without a real client install is to use the
+        # IPA CLI inside the container — skip if we can't confirm the flag)
+        host_data = execute_ipa_command(client, "host_show", fqdn)
+        result = host_data.get("result", {}) if isinstance(host_data, dict) else {}
+        if not result.get("has_keytab"):
+            ipa_host_del(vm_name, namespace)
+            pytest.skip("Cannot simulate keytab presence without a real client enroll")
+
+        try:
+            with pytest.raises(RuntimeError, match="already enrolled"):
+                ipa_host_add(vm_name, namespace, str(uuid.uuid4()))
+        finally:
+            ipa_host_del(vm_name, namespace)
 
     def test_fqdn_format(self):
         """FQDN should follow the vmname.namespace.domain pattern."""


### PR DESCRIPTION
## Summary

- Fix `REALM=None` bug causing `--realm=None` to be injected into VM cloud-init
- Add `/readyz` readiness probe (separate from `/healthz`) that additionally checks IPA reachability
- Add `/metrics` Prometheus endpoint via `prometheus-fastapi-instrumentator`
- Add exponential backoff to controller reconnect (5→60s) and `send_delayed_creation_event` (2→30s, 10 attempts)
- Make `ipa_host_add` idempotent on K8s admission retries (catch duplicate-entry errors)
- Centralize K8s config loading into `_ensure_k8s_config()` (called once, reused everywhere)
- Track background tasks (`create_tracked_task`) so they are cancelled cleanly on shutdown
- Simplify `execute_ipa_command` (remove dead/redundant code branch)
- Fix `readinessProbe` in `deployment.yaml` to use `/readyz`
- Fix `mock_ipa_client` test fixture to return correct `(client, hostname)` tuple
- Add `CLAUDE.md` for Claude Code guidance
- Expand deploy docs with probe behaviour and Prometheus `ServiceMonitor` example

## Test plan

- [x] All 17 existing unit tests pass
- [x] New `test_mutate_vm_realm_fallback` test added and passing
- [x] `test_retry_logic_failure` updated to reflect 10-attempt backoff
- [ ] Deploy to a dev cluster and verify `/healthz`, `/readyz`, and `/metrics` endpoints respond correctly
- [ ] Confirm Prometheus scraping works with the `ServiceMonitor` example in the updated deploy docs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)