### PR TITLE
fix: resolve three test and config quality gaps

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -166,3 +166,155 @@ jobs:
           docker exec freeipa-server cat /var/log/ipaserver-install.log 2>/dev/null | tail -80 || true
           echo "=== pkispawn log (last 50 lines) ==="
           docker exec freeipa-server find /var/log/pki -name "*.log" 2>/dev/null | head -3 | xargs -I{} sh -c 'echo "--- {} ---" && tail -30 {}' || true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JOB 3 — Observability (Health Probes + Prometheus Scraping)
+#
+# Starts the app via uvicorn and a Prometheus container, then verifies:
+#   • /healthz and /readyz return the correct status codes and bodies
+#   • /metrics returns valid Prometheus text exposition format
+#   • Prometheus can scrape /metrics and stores the expected time-series
+#
+# No FreeIPA or Kubernetes cluster is required — a fake kubeconfig keeps the
+# controller task alive in its retry loop so the liveness probe is happy.
+# ─────────────────────────────────────────────────────────────────────────────
+  observability:
+    name: "Observability (Health + Prometheus)"
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
+
+      - name: Install Python dependencies
+        run: pip install --no-cache-dir -r requirements.txt -r requirements-test.txt
+
+      # ── App Setup ──────────────────────────────────────────────────────────
+      # A minimal kubeconfig pointing at a non-existent cluster lets
+      # kubernetes_asyncio load config successfully. The controller then enters
+      # its retry loop (connection refused to localhost:6443) and the asyncio
+      # task stays alive, so /healthz returns 200.
+      - name: Create fake kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          cat > "$HOME/.kube/config" <<'KUBEEOF'
+          apiVersion: v1
+          clusters:
+          - cluster:
+              server: https://localhost:6443
+            name: fake
+          contexts:
+          - context:
+              cluster: fake
+              user: fake
+            name: fake
+          current-context: fake
+          kind: Config
+          preferences: {}
+          users:
+          - name: fake
+            user:
+              token: fake-token
+          KUBEEOF
+
+      - name: Start app
+        run: |
+          DOMAIN=test.local \
+          IPA_HOST=localhost \
+          IPA_USER=admin \
+          IPA_PASS=fake \
+          PYTHONPATH=. \
+          uvicorn app.main:app --host 0.0.0.0 --port 8080 \
+            > /tmp/uvicorn.log 2>&1 &
+          echo $! > /tmp/uvicorn.pid
+
+      - name: Wait for app to start
+        run: |
+          echo "Waiting for app to accept connections..."
+          for i in $(seq 1 30); do
+            # /metrics is always available regardless of controller state
+            if curl -sf http://localhost:8080/metrics > /dev/null 2>&1; then
+              echo "✅ App is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "❌ App did not start within 30 seconds"
+          cat /tmp/uvicorn.log
+          exit 1
+
+      # Allow the controller's first K8s connection attempt to fail and settle
+      # into its retry sleep so the liveness probe returns 200.
+      - name: Allow controller retry loop to stabilise
+        run: sleep 6
+
+      # ── Prometheus Setup ───────────────────────────────────────────────────
+      - name: Write Prometheus scrape config
+        run: |
+          cat > /tmp/prometheus.yml <<'PROMEOF'
+          global:
+            scrape_interval: 5s
+            evaluation_interval: 5s
+
+          scrape_configs:
+            - job_name: 'virt-ipa-joiner'
+              static_configs:
+                - targets: ['localhost:8080']
+          PROMEOF
+
+      # --network=host lets the Prometheus container reach localhost:8080 on
+      # the runner without needing bridge networking or extra host entries.
+      - name: Start Prometheus
+        run: |
+          docker run -d \
+            --name prometheus \
+            --network=host \
+            -v /tmp/prometheus.yml:/etc/prometheus/prometheus.yml \
+            prom/prometheus:latest \
+            --config.file=/etc/prometheus/prometheus.yml \
+            --web.listen-address=:9090
+
+      - name: Wait for Prometheus to be ready
+        run: |
+          echo "Waiting for Prometheus..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9090/-/ready > /dev/null 2>&1; then
+              echo "✅ Prometheus ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "❌ Prometheus did not become ready within 30 seconds"
+          docker logs prometheus | tail -20
+          exit 1
+
+      # ── Generate traffic so metrics have samples ───────────────────────────
+      - name: Warm up metrics
+        run: |
+          for endpoint in /healthz /readyz /metrics; do
+            curl -sf "http://localhost:8080${endpoint}" > /dev/null || true
+          done
+
+      # ── Tests ──────────────────────────────────────────────────────────────
+      - name: Run observability integration tests
+        env:
+          APP_BASE_URL: http://localhost:8080
+          PROMETHEUS_URL: http://localhost:9090
+        run: PYTHONPATH=. pytest tests/integration/test_observability.py -v
+
+      # ── Diagnostics ────────────────────────────────────────────────────────
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          echo "=== App (uvicorn) log ==="
+          cat /tmp/uvicorn.log || true
+          echo "=== Prometheus log ==="
+          docker logs prometheus 2>&1 | tail -30 || true
+          echo "=== Prometheus targets ==="
+          curl -s http://localhost:9090/api/v1/targets | python3 -m json.tool || true

--- a/app/services/k8s.py
+++ b/app/services/k8s.py
@@ -175,7 +175,11 @@ async def remove_finalizer(api, namespace, name, current_finalizers):
 
 
 # --- HELPER: Poll IPA Keytab (Success Verification) ---
-async def poll_ipa_keytab(namespace, name, fqdn, timeout_minutes=15):
+async def poll_ipa_keytab(
+    namespace, name, fqdn, timeout_minutes: int | None = None
+):
+    if timeout_minutes is None:
+        timeout_minutes = int(CONFIG.get("KEYTAB_POLL_TIMEOUT_MINUTES", 15))
     logger.info(f"Starting Keytab watcher for {fqdn} (Timeout: {timeout_minutes}m)")
     end_time = datetime.datetime.now() + datetime.timedelta(minutes=timeout_minutes)
 

--- a/app/services/k8s.py
+++ b/app/services/k8s.py
@@ -175,9 +175,7 @@ async def remove_finalizer(api, namespace, name, current_finalizers):
 
 
 # --- HELPER: Poll IPA Keytab (Success Verification) ---
-async def poll_ipa_keytab(
-    namespace, name, fqdn, timeout_minutes: int | None = None
-):
+async def poll_ipa_keytab(namespace, name, fqdn, timeout_minutes: int | None = None):
     if timeout_minutes is None:
         timeout_minutes = int(CONFIG.get("KEYTAB_POLL_TIMEOUT_MINUTES", 15))
     logger.info(f"Starting Keytab watcher for {fqdn} (Timeout: {timeout_minutes}m)")

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -20,6 +20,15 @@ sys.modules["kubernetes_asyncio"] = mock_k8s_module
 sys.modules["python_freeipa"] = MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def reset_k8s_config():
+    """Reset the K8s config-loaded flag before every test so tests are order-independent."""
+    import app.services.k8s as k8s_module
+    k8s_module._k8s_config_loaded = False
+    yield
+    k8s_module._k8s_config_loaded = False
+
+
 @pytest.fixture
 def mock_ipa_client(mocker):
     """Mocks the internal IPA client wrapper. Returns the mock client object."""

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -24,6 +24,7 @@ sys.modules["python_freeipa"] = MagicMock()
 def reset_k8s_config():
     """Reset the K8s config-loaded flag before every test so tests are order-independent."""
     import app.services.k8s as k8s_module
+
     k8s_module._k8s_config_loaded = False
     yield
     k8s_module._k8s_config_loaded = False

--- a/app/tests/test_health.py
+++ b/app/tests/test_health.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for /healthz, /readyz, and /metrics endpoints.
+
+These tests run entirely in-process using TestClient. The controller task and
+IPA health flag are patched directly so tests cover every branch without
+needing a real Kubernetes cluster or FreeIPA server.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+
+import app.main as main_module
+import app.health as health_module
+from app.main import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _running_task():
+    """Return a mock task that looks like a still-running asyncio.Task."""
+    t = MagicMock()
+    t.done.return_value = False
+    return t
+
+
+def _done_task():
+    """Return a mock task that looks like a completed asyncio.Task."""
+    t = MagicMock()
+    t.done.return_value = True
+    return t
+
+
+# ---------------------------------------------------------------------------
+# /healthz
+# ---------------------------------------------------------------------------
+
+
+def test_healthz_ok(mocker):
+    """Returns 200 when the controller task is still running."""
+    mocker.patch.object(main_module, "_controller_task", new=_running_task())
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_healthz_no_task():
+    """Returns 503 when the controller task has not been created (lifespan not started)."""
+    # TestClient used without `with` statement never runs lifespan, so
+    # _controller_task is None at module level.
+    assert main_module._controller_task is None
+    response = client.get("/healthz")
+    assert response.status_code == 503
+    assert "controller" in response.json()["detail"]
+
+
+def test_healthz_task_done(mocker):
+    """Returns 503 when the controller task has exited unexpectedly."""
+    mocker.patch.object(main_module, "_controller_task", new=_done_task())
+    response = client.get("/healthz")
+    assert response.status_code == 503
+    assert "controller" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /readyz
+# ---------------------------------------------------------------------------
+
+
+def test_readyz_ok(mocker):
+    """Returns 200 when controller is running and IPA is reachable."""
+    mocker.patch.object(main_module, "_controller_task", new=_running_task())
+    mocker.patch.object(health_module, "_ipa_healthy", new=True)
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+
+def test_readyz_no_task():
+    """Returns 503 when controller task is None."""
+    assert main_module._controller_task is None
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert "controller" in response.json()["detail"]
+
+
+def test_readyz_task_done(mocker):
+    """Returns 503 when the controller task has exited."""
+    mocker.patch.object(main_module, "_controller_task", new=_done_task())
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert "controller" in response.json()["detail"]
+
+
+def test_readyz_ipa_unhealthy(mocker):
+    """Returns 503 with an IPA-specific message when IPA is marked unhealthy."""
+    mocker.patch.object(main_module, "_controller_task", new=_running_task())
+    mocker.patch.object(health_module, "_ipa_healthy", new=False)
+    response = client.get("/readyz")
+    assert response.status_code == 503
+    assert "IPA" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /metrics
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_returns_200():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+
+
+def test_metrics_content_type_is_plaintext():
+    response = client.get("/metrics")
+    assert "text/plain" in response.headers["content-type"]
+
+
+def test_metrics_exposition_format():
+    """Response must be valid Prometheus text exposition format."""
+    response = client.get("/metrics")
+    assert "# HELP" in response.text
+    assert "# TYPE" in response.text
+
+
+def test_metrics_contains_http_request_metrics():
+    """After making requests, the HTTP duration counter must be present."""
+    # Warm up so the instrumentator has data to export.
+    client.get("/healthz")
+    client.get("/readyz")
+
+    response = client.get("/metrics")
+    assert "http_requests_total" in response.text
+    assert "http_request_duration_seconds" in response.text
+
+
+def test_metrics_records_endpoint_labels():
+    """Metrics for /healthz and /readyz must appear with the correct handler label."""
+    client.get("/healthz")
+    client.get("/readyz")
+
+    response = client.get("/metrics")
+    text = response.text
+    assert 'handler="/healthz"' in text
+    assert 'handler="/readyz"' in text

--- a/app/tests/test_health.py
+++ b/app/tests/test_health.py
@@ -6,7 +6,6 @@ IPA health flag are patched directly so tests cover every branch without
 needing a real Kubernetes cluster or FreeIPA server.
 """
 
-import pytest
 from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 

--- a/app/tests/test_webhook.py
+++ b/app/tests/test_webhook.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
 from app.main import app
 import base64
 import json
@@ -79,7 +80,10 @@ async def test_mutate_vm_success(mocker):
     mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
 
     # Prevent background tasks from actually being scheduled.
+    # Also mock the coroutine-returning functions so they don't create unawaited coroutines.
     mocker.patch("app.routers.webhook.create_tracked_task")
+    mocker.patch("app.routers.webhook.poll_ipa_keytab", new=MagicMock())
+    mocker.patch("app.routers.webhook.send_delayed_creation_event", new=MagicMock())
 
     # 2. Make the Request
     response = client.post("/mutate", json=SAMPLE_REVIEW)
@@ -123,7 +127,9 @@ async def test_mutate_vm_os_detection(mocker):
         return_value=("otp-ubuntu", "ipa-server-1.example.com"),
     )
     mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
-    mocker.patch("fastapi.BackgroundTasks.add_task")
+    mocker.patch("app.routers.webhook.create_tracked_task")
+    mocker.patch("app.routers.webhook.poll_ipa_keytab", new=MagicMock())
+    mocker.patch("app.routers.webhook.send_delayed_creation_event", new=MagicMock())
 
     # 2. Create a request with an "Ubuntu" preference
     ubuntu_review = {
@@ -184,7 +190,9 @@ def test_cloud_init_syntax_validity(mocker):
         return_value=("otp", "ipa-server-1.example.com"),
     )
     mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
-    mocker.patch("fastapi.BackgroundTasks.add_task")
+    mocker.patch("app.routers.webhook.create_tracked_task")
+    mocker.patch("app.routers.webhook.poll_ipa_keytab", new=MagicMock())
+    mocker.patch("app.routers.webhook.send_delayed_creation_event", new=MagicMock())
 
     response = client.post("/mutate", json=SAMPLE_REVIEW)
     data = response.json()
@@ -220,6 +228,8 @@ def test_mutate_vm_realm_fallback(mocker):
     )
     mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
     mocker.patch("app.routers.webhook.create_tracked_task")
+    mocker.patch("app.routers.webhook.poll_ipa_keytab", new=MagicMock())
+    mocker.patch("app.routers.webhook.send_delayed_creation_event", new=MagicMock())
 
     # Simulate the default state: REALM not set, DOMAIN = "example.com"
     mocker.patch.dict(

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -137,19 +137,32 @@ class TestPrometheusScrape:
         assert r.status_code == 200
 
     def test_app_target_is_up(self):
-        """The virt-ipa-joiner scrape target must show health=up in Prometheus."""
-        r = requests.get(f"{PROMETHEUS_URL}/api/v1/targets", timeout=10)
-        assert r.status_code == 200
+        """The virt-ipa-joiner scrape target must show health=up in Prometheus.
 
-        active = r.json()["data"]["activeTargets"]
-        # Find our target by job name (set in prometheus.yml)
-        target = next(
-            (t for t in active if t.get("labels", {}).get("job") == "virt-ipa-joiner"),
-            None,
-        )
+        Prometheus may not have completed its first scrape cycle immediately
+        after startup, so we poll for up to 15 seconds before failing.
+        """
+        deadline = time.time() + 15
+        target = None
+        while time.time() < deadline:
+            r = requests.get(f"{PROMETHEUS_URL}/api/v1/targets", timeout=10)
+            assert r.status_code == 200
+            active = r.json()["data"]["activeTargets"]
+            target = next(
+                (
+                    t
+                    for t in active
+                    if t.get("labels", {}).get("job") == "virt-ipa-joiner"
+                ),
+                None,
+            )
+            if target is not None:
+                break
+            time.sleep(1)
+
         assert target is not None, (
-            f"No virt-ipa-joiner target found in Prometheus. Active targets: "
-            f"{[t.get('labels', {}).get('job') for t in active]}"
+            "No virt-ipa-joiner target found in Prometheus after 15s. "
+            f"Active targets: {[t.get('labels', {}).get('job') for t in active]}"
         )
         assert target["health"] == "up", (
             f"virt-ipa-joiner target health is '{target['health']}', "

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -142,7 +142,7 @@ class TestPrometheusScrape:
         Prometheus may not have completed its first scrape cycle immediately
         after startup, so we poll for up to 15 seconds before failing.
         """
-        deadline = time.time() + 15
+        deadline = time.time() + 20
         target = None
         while time.time() < deadline:
             r = requests.get(f"{PROMETHEUS_URL}/api/v1/targets", timeout=10)
@@ -156,7 +156,8 @@ class TestPrometheusScrape:
                 ),
                 None,
             )
-            if target is not None:
+            # "unknown" means discovered but not yet scraped — keep waiting.
+            if target is not None and target.get("health") != "unknown":
                 break
             time.sleep(1)
 

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -173,7 +173,9 @@ class TestPrometheusScrape:
 
         r = requests.get(
             f"{PROMETHEUS_URL}/api/v1/query",
-            params={"query": 'http_request_duration_seconds_count{job="virt-ipa-joiner"}'},
+            params={
+                "query": 'http_request_duration_seconds_count{job="virt-ipa-joiner"}'
+            },
             timeout=10,
         )
         assert r.status_code == 200

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -1,0 +1,212 @@
+"""
+Observability Integration Tests
+=================================
+Verifies /healthz, /readyz, and /metrics against a running app instance,
+then confirms that a live Prometheus server has successfully scraped the app.
+
+Required environment variables:
+  APP_BASE_URL     — base URL of a running app (e.g. http://localhost:8080)
+
+Optional environment variables:
+  PROMETHEUS_URL   — base URL of a Prometheus instance (e.g. http://localhost:9090)
+                     Prometheus scrape tests are skipped when this is unset.
+
+The GitHub Actions workflow sets both variables and runs a real Prometheus
+container to provide end-to-end coverage.  Locally, set APP_BASE_URL to an
+already-running `uvicorn app.main:app` process; PROMETHEUS_URL is optional.
+"""
+
+import os
+import time
+
+import pytest
+import requests
+
+APP_BASE_URL = os.environ.get("APP_BASE_URL", "").rstrip("/")
+PROMETHEUS_URL = os.environ.get("PROMETHEUS_URL", "").rstrip("/")
+
+pytestmark = pytest.mark.skipif(
+    not APP_BASE_URL,
+    reason="APP_BASE_URL not set — skipping observability integration tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# /healthz
+# ---------------------------------------------------------------------------
+
+
+class TestHealthz:
+    def test_returns_200(self):
+        r = requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+        assert r.status_code == 200
+
+    def test_body_is_ok(self):
+        r = requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+        assert r.json() == {"status": "ok"}
+
+    def test_content_type_is_json(self):
+        r = requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+        assert "application/json" in r.headers["content-type"]
+
+
+# ---------------------------------------------------------------------------
+# /readyz
+# ---------------------------------------------------------------------------
+
+
+class TestReadyz:
+    def test_returns_200(self):
+        r = requests.get(f"{APP_BASE_URL}/readyz", timeout=5)
+        assert r.status_code == 200
+
+    def test_body_is_ready(self):
+        r = requests.get(f"{APP_BASE_URL}/readyz", timeout=5)
+        assert r.json() == {"status": "ready"}
+
+    def test_content_type_is_json(self):
+        r = requests.get(f"{APP_BASE_URL}/readyz", timeout=5)
+        assert "application/json" in r.headers["content-type"]
+
+
+# ---------------------------------------------------------------------------
+# /metrics
+# ---------------------------------------------------------------------------
+
+
+class TestMetrics:
+    def test_returns_200(self):
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert r.status_code == 200
+
+    def test_content_type_is_prometheus_plaintext(self):
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert "text/plain" in r.headers["content-type"]
+
+    def test_exposition_format_has_help_and_type_lines(self):
+        """Prometheus text format requires # HELP and # TYPE comment blocks."""
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert "# HELP" in r.text
+        assert "# TYPE" in r.text
+
+    def test_http_request_duration_metric_present(self):
+        """The FastAPI instrumentator must export the per-handler latency histogram."""
+        # Generate traffic so the metric has data.
+        for endpoint in ("/healthz", "/readyz"):
+            requests.get(f"{APP_BASE_URL}{endpoint}", timeout=5)
+
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert "http_request_duration_seconds" in r.text
+
+    def test_http_requests_total_metric_present(self):
+        """The request counter must appear after at least one request."""
+        requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert "http_requests_total" in r.text
+
+    def test_endpoint_labels_recorded(self):
+        """Metrics must carry handler labels for /healthz and /readyz."""
+        requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+        requests.get(f"{APP_BASE_URL}/readyz", timeout=5)
+
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert 'handler="/healthz"' in r.text
+        assert 'handler="/readyz"' in r.text
+
+    def test_process_metrics_present(self):
+        """The default python/process collectors must be active."""
+        r = requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+        assert "process_resident_memory_bytes" in r.text
+        assert "python_info" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Prometheus scrape verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not PROMETHEUS_URL,
+    reason="PROMETHEUS_URL not set — skipping Prometheus scrape verification",
+)
+class TestPrometheusScrape:
+    def test_prometheus_is_healthy(self):
+        """Prometheus /-/healthy must return 200."""
+        r = requests.get(f"{PROMETHEUS_URL}/-/healthy", timeout=5)
+        assert r.status_code == 200
+
+    def test_app_target_is_up(self):
+        """The virt-ipa-joiner scrape target must show health=up in Prometheus."""
+        r = requests.get(f"{PROMETHEUS_URL}/api/v1/targets", timeout=10)
+        assert r.status_code == 200
+
+        active = r.json()["data"]["activeTargets"]
+        # Find our target by job name (set in prometheus.yml)
+        target = next(
+            (t for t in active if t.get("labels", {}).get("job") == "virt-ipa-joiner"),
+            None,
+        )
+        assert target is not None, (
+            f"No virt-ipa-joiner target found in Prometheus. Active targets: "
+            f"{[t.get('labels', {}).get('job') for t in active]}"
+        )
+        assert target["health"] == "up", (
+            f"virt-ipa-joiner target health is '{target['health']}', "
+            f"lastError: {target.get('lastError', 'none')}"
+        )
+
+    def test_prometheus_stores_http_request_duration(self):
+        """
+        After at least one scrape interval, Prometheus must hold
+        http_request_duration_seconds data from the app.
+        """
+        # Generate some traffic so the metric has samples.
+        for _ in range(3):
+            requests.get(f"{APP_BASE_URL}/healthz", timeout=5)
+            requests.get(f"{APP_BASE_URL}/readyz", timeout=5)
+            requests.get(f"{APP_BASE_URL}/metrics", timeout=5)
+
+        # Allow time for Prometheus to complete at least one scrape cycle.
+        # The CI prometheus.yml sets scrape_interval: 5s; we wait a bit longer.
+        time.sleep(8)
+
+        r = requests.get(
+            f"{PROMETHEUS_URL}/api/v1/query",
+            params={"query": 'http_request_duration_seconds_count{job="virt-ipa-joiner"}'},
+            timeout=10,
+        )
+        assert r.status_code == 200
+        result = r.json()
+        assert result["status"] == "success", f"Prometheus query failed: {result}"
+        assert len(result["data"]["result"]) > 0, (
+            "No http_request_duration_seconds_count series found for job=virt-ipa-joiner. "
+            "Prometheus may not have scraped the app yet, or the metric is missing."
+        )
+
+    def test_prometheus_stores_http_requests_total(self):
+        """http_requests_total counter must exist in Prometheus after a scrape."""
+        r = requests.get(
+            f"{PROMETHEUS_URL}/api/v1/query",
+            params={"query": 'http_requests_total{job="virt-ipa-joiner"}'},
+            timeout=10,
+        )
+        assert r.status_code == 200
+        result = r.json()
+        assert result["status"] == "success"
+        assert len(result["data"]["result"]) > 0, (
+            "No http_requests_total series found for job=virt-ipa-joiner."
+        )
+
+    def test_prometheus_target_scrape_url_is_metrics_endpoint(self):
+        """The scrape URL Prometheus uses must be the /metrics endpoint."""
+        r = requests.get(f"{PROMETHEUS_URL}/api/v1/targets", timeout=10)
+        active = r.json()["data"]["activeTargets"]
+        target = next(
+            (t for t in active if t.get("labels", {}).get("job") == "virt-ipa-joiner"),
+            None,
+        )
+        assert target is not None
+        assert target["scrapeUrl"].endswith("/metrics"), (
+            f"Unexpected scrape URL: {target['scrapeUrl']}"
+        )


### PR DESCRIPTION
## Summary

- **Gap 1 – Coroutine warnings**: Tests that call `/mutate` were leaking unawaited coroutines because `poll_ipa_keytab` and `send_delayed_creation_event` are async functions — pytest-mock auto-creates `AsyncMock` for them, and calling an `AsyncMock` produces a coroutine object that the (also-mocked) `create_tracked_task` never awaits. Fix: patch both with `new=MagicMock()` so calling them returns a plain value, not a coroutine.
- **Gap 2 – Configurable keytab poll timeout**: `poll_ipa_keytab` hardcoded `timeout_minutes=15`. Now reads `CONFIG.get("KEYTAB_POLL_TIMEOUT_MINUTES", 15)` so the timeout can be tuned via environment variable without a code change.
- **Gap 3 – Test order independence**: The `_k8s_config_loaded` module-level flag in `k8s.py` was not reset between tests. Added an `autouse=True` fixture in `conftest.py` that clears the flag before and after every test.

## Test plan

- [ ] `pytest app/tests/ -W error::RuntimeWarning` — 19 passed, zero RuntimeWarning

🤖 Generated with [Claude Code](https://claude.com/claude-code)