### PR TITLE
fix: normalise REALM to uppercase to prevent enrolment mismatch

### DIFF
--- a/app/routers/webhook.py
+++ b/app/routers/webhook.py
@@ -147,7 +147,7 @@ async def mutate_vm(review: Dict[str, Any] = Body(...)):
                 install_cmd_str = os_cmd
                 break
 
-        realm_arg = CONFIG.get("REALM") or CONFIG["DOMAIN"].upper()
+        realm_arg = (CONFIG.get("REALM") or CONFIG["DOMAIN"]).upper()
 
         ipa_cmd_parts = [
             "ipa-client-install",

--- a/app/tests/test_webhook.py
+++ b/app/tests/test_webhook.py
@@ -255,3 +255,38 @@ def test_mutate_vm_realm_fallback(mocker):
     # Must contain the uppercased domain, not the string "None".
     assert "--realm=EXAMPLE.COM" in user_data
     assert "--realm=None" not in user_data
+
+
+def test_mutate_vm_realm_lowercased_is_normalised(mocker):
+    """
+    Verifies that a lowercase REALM value is upper-cased before being passed
+    to ipa-client-install. IPA stores realms uppercased, so a lowercase value
+    causes 'realm does not match any realm in LDAP database' on enrolment.
+    """
+    mocker.patch(
+        "app.routers.webhook.ipa_host_add",
+        return_value=("otp-realm-test", "ipa-server.example.com"),
+    )
+    mocker.patch("app.routers.webhook.check_should_enroll", return_value=True)
+    mocker.patch("app.routers.webhook.create_tracked_task")
+    mocker.patch("app.routers.webhook.poll_ipa_keytab", new=MagicMock())
+    mocker.patch("app.routers.webhook.send_delayed_creation_event", new=MagicMock())
+
+    mocker.patch.dict(
+        "app.routers.webhook.CONFIG",
+        {"REALM": "lab.example.com", "DOMAIN": "lab.example.com"},
+    )
+
+    response = client.post("/mutate", json=SAMPLE_REVIEW)
+    assert response.status_code == 200
+
+    patch_decoded = base64.b64decode(response.json()["response"]["patch"]).decode()
+    patch_obj = json.loads(patch_decoded)
+    volume_patch = next(
+        (op for op in patch_obj if "volumes" in op.get("path", "")), None
+    )
+    assert volume_patch is not None
+
+    user_data = volume_patch["value"]["cloudInitNoCloud"]["userData"]
+    assert "--realm=LAB.EXAMPLE.COM" in user_data
+    assert "--realm=lab.example.com" not in user_data


### PR DESCRIPTION
## Summary
- A lowercase `REALM` config value was passed through to `ipa-client-install` verbatim, causing `realm does not match any realm in LDAP database` on enrolment, since FreeIPA stores realms uppercased.
- Moved `.upper()` outside the `or` so it applies to an explicit `REALM` too, not only the `DOMAIN` fallback.
- Added a regression test (`test_mutate_vm_realm_lowercased_is_normalised`) covering the lowercase-input path; existing fallback test still asserts the `DOMAIN.upper()` behaviour.

## Test plan
- [x] `PYTHONPATH=. pytest app/tests/test_webhook.py -k realm` passes (both `_fallback` and new `_lowercased_is_normalised`)
- [ ] Deploy and create a VM with `REALM=lab.example.com` (lowercase) to confirm `ipa-client-install` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)