### PR TITLE
fix: scope FQDN length check to enrolling VMs and skip self-FQDN names

### DIFF
--- a/app/routers/webhook.py
+++ b/app/routers/webhook.py
@@ -57,10 +57,19 @@ async def mutate_vm(review: Dict[str, Any] = Body(...)):
             "response": {"uid": admission_uid, "allowed": True},
         }
 
-    # Construct the target FQDN early to validate it
-    fqdn = build_fqdn(vm_name, namespace)
+    should_enroll = await check_should_enroll(vm_object, namespace)
 
+    if not should_enroll:
+        return {
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "response": {"uid": admission_uid, "allowed": True},
+        }
+
+    # Only enforce the FQDN length budget on VMs we actually enrol —
+    # unrelated VMs with long names must never be blocked by us.
     # Linux HOST_NAME_MAX is typically 64.
+    fqdn = build_fqdn(vm_name, namespace)
     if len(fqdn) > 64:
         error_msg = f"Generated FQDN '{fqdn}' is {len(fqdn)} chars. Max allowed is 64."
         logger.warning(f"Rejected VM {vm_name}: {error_msg}")
@@ -72,15 +81,6 @@ async def mutate_vm(review: Dict[str, Any] = Body(...)):
                 "allowed": False,
                 "status": {"message": error_msg, "code": 400},
             },
-        }
-
-    should_enroll = await check_should_enroll(vm_object, namespace)
-
-    if not should_enroll:
-        return {
-            "apiVersion": "admission.k8s.io/v1",
-            "kind": "AdmissionReview",
-            "response": {"uid": admission_uid, "allowed": True},
         }
 
     patch = []

--- a/app/services/ipa.py
+++ b/app/services/ipa.py
@@ -187,4 +187,9 @@ def ipa_host_del(vm_name: str, namespace: str):
 def build_fqdn(vm_name: str, namespace: str) -> str:
     # Handle case sensitivity of config keys if needed
     domain = CONFIG.get("DOMAIN") or CONFIG.get("domain")
+    # If the VM was named with the exact FQDN we would have generated,
+    # don't double-append the namespace and domain.
+    suffix = f".{namespace}.{domain}"
+    if vm_name.endswith(suffix):
+        return vm_name
     return f"{vm_name}.{namespace}.{domain}"

--- a/app/tests/test_ipa.py
+++ b/app/tests/test_ipa.py
@@ -163,9 +163,7 @@ def test_build_fqdn_full_fqdn_name_is_not_duplicated(mocker):
     return it as-is rather than appending namespace/domain a second time.
     """
     mocker.patch.dict("app.services.ipa.CONFIG", {"DOMAIN": "example.com"})
-    assert (
-        build_fqdn("web1.prod.example.com", "prod") == "web1.prod.example.com"
-    )
+    assert build_fqdn("web1.prod.example.com", "prod") == "web1.prod.example.com"
 
 
 def test_build_fqdn_unrelated_dotted_name_is_still_appended(mocker):
@@ -175,7 +173,4 @@ def test_build_fqdn_unrelated_dotted_name_is_still_appended(mocker):
     a non-conventional name; this is intentional behaviour, not a feature.
     """
     mocker.patch.dict("app.services.ipa.CONFIG", {"DOMAIN": "example.com"})
-    assert (
-        build_fqdn("web1.example.com", "prod")
-        == "web1.example.com.prod.example.com"
-    )
+    assert build_fqdn("web1.example.com", "prod") == "web1.example.com.prod.example.com"

--- a/app/tests/test_ipa.py
+++ b/app/tests/test_ipa.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, call
 import dns.resolver
-from app.services.ipa import ipa_resolve_srv, get_ipa_client, ipa_host_add
+from app.services.ipa import ipa_resolve_srv, get_ipa_client, ipa_host_add, build_fqdn
 
 # --- Test DNS Resolution ---
 
@@ -146,3 +146,36 @@ def test_host_add_raises_when_host_already_enrolled(mocker):
 
     with pytest.raises(RuntimeError, match="already enrolled"):
         ipa_host_add("my-vm", "default", "test-uuid-5678")
+
+
+# --- Test build_fqdn ---
+
+
+def test_build_fqdn_short_name_constructs_full(mocker):
+    """A bare VM name gets the namespace and domain appended."""
+    mocker.patch.dict("app.services.ipa.CONFIG", {"DOMAIN": "example.com"})
+    assert build_fqdn("web1", "prod") == "web1.prod.example.com"
+
+
+def test_build_fqdn_full_fqdn_name_is_not_duplicated(mocker):
+    """
+    If the VM was named with the exact FQDN we would have generated,
+    return it as-is rather than appending namespace/domain a second time.
+    """
+    mocker.patch.dict("app.services.ipa.CONFIG", {"DOMAIN": "example.com"})
+    assert (
+        build_fqdn("web1.prod.example.com", "prod") == "web1.prod.example.com"
+    )
+
+
+def test_build_fqdn_unrelated_dotted_name_is_still_appended(mocker):
+    """
+    A dotted VM name that does not match our generated suffix is treated as
+    a label, not an FQDN — we still construct the full name. The user picked
+    a non-conventional name; this is intentional behaviour, not a feature.
+    """
+    mocker.patch.dict("app.services.ipa.CONFIG", {"DOMAIN": "example.com"})
+    assert (
+        build_fqdn("web1.example.com", "prod")
+        == "web1.example.com.prod.example.com"
+    )

--- a/app/tests/test_webhook.py
+++ b/app/tests/test_webhook.py
@@ -69,6 +69,43 @@ async def test_mutate_vm_fqdn_too_long(mocker):
 
 
 @pytest.mark.asyncio
+async def test_mutate_vm_fqdn_too_long_without_enrol_label_is_allowed(mocker):
+    """
+    A long-named VM that did NOT opt into IPA enrolment must never be blocked
+    by our webhook — the 64-char FQDN check is only relevant when we are
+    going to enrol.
+    """
+    long_name = "a" * 40
+    long_namespace = "b" * 20
+
+    request_data = {
+        "request": {
+            "uid": "123",
+            "namespace": long_namespace,
+            "object": {
+                "metadata": {
+                    "name": long_name,
+                    "namespace": long_namespace,
+                    # No ipa-enroll label, no instancetype → must be left alone.
+                },
+                "spec": {"template": {"spec": {}}},
+            },
+        }
+    }
+
+    # ipa_host_add must not be reached.
+    add_mock = mocker.patch("app.routers.webhook.ipa_host_add")
+
+    response = client.post("/mutate", json=request_data)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["response"]["allowed"] is True
+    assert "patch" not in data["response"]
+    add_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_mutate_vm_success(mocker):
     # 1. Mock the dependencies
     mocker.patch(


### PR DESCRIPTION
## Summary
Two related fixes to FQDN handling in the mutating webhook:

1. **FQDN length check no longer blocks non-enrolling VMs.** The 64-char check at `app/routers/webhook.py` ran *before* `check_should_enroll()`, so any VM with a long generated name was hard-rejected even when it had no `ipa-enroll` label. The check now runs only after we've decided the VM is in scope.
2. **`build_fqdn` no longer double-suffixes a VM named with its full FQDN.** Previously, naming a VM `web1.prod.example.com` in namespace `prod` with domain `example.com` produced `web1.prod.example.com.prod.example.com`. If the name already ends with `.<namespace>.<domain>`, return it as-is.

## Test plan
- [x] `PYTHONPATH=. pytest -q` — 40 passed, 39 skipped (e2e)
- [x] New unit tests:
  - `test_mutate_vm_fqdn_too_long_without_enrol_label_is_allowed` — long-named VM with no label is `allowed: true`, no patch, `ipa_host_add` not called
  - `test_build_fqdn_short_name_constructs_full` — baseline
  - `test_build_fqdn_full_fqdn_name_is_not_duplicated` — self-FQDN case
  - `test_build_fqdn_unrelated_dotted_name_is_still_appended` — pins the "user used wrong shape" behaviour
- [ ] In-cluster: create a long-named VM with no `ipa-enroll` label and confirm it is admitted unchanged
- [ ] In-cluster: create a VM named `myvm.prod.<domain>` with `ipa-enroll: "true"` and confirm IPA registration uses `myvm.prod.<domain>` exactly

## Out of scope (follow-ups)
- GitOps drift (ArgoCD/Terraform/Ansible reverting injected cloud-init)
- VMs that use `userDataSecretRef` / `networkDataSecretRef` instead of inline userData

🤖 Generated with [Claude Code](https://claude.com/claude-code)