### PR TITLE
feat: migrate to Red Hat Hardened Images and Python 3.14

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       # python-freeipa and kubernetes-asyncio need these system libs to compile.
       - name: Install system dependencies
@@ -137,7 +137,7 @@ jobs:
       # ── Python Setup ───────────────────────────────────────────────────────
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install system dependencies
         run: sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
@@ -232,7 +232,7 @@ jobs:
       # ── Python + App Setup ─────────────────────────────────────────────────
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install system dependencies
         run: sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
@@ -357,7 +357,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install system dependencies
         run: sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline (Podman/UBI)
+name: CI/CD Pipeline (Podman/Hardened)
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install Ruff
         run: pip install ruff
@@ -44,13 +44,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Run Tests in UBI Container
+      - name: Run Tests in Hardened Builder Container
         run: |
           podman run --rm \
             -u 0 \
             -v ${{ github.workspace }}:/app:z \
             -w /app \
-            registry.access.redhat.com/ubi9/python-312:latest \
+            registry.access.redhat.com/hi/python:3.14-builder \
             /bin/bash -c "
               dnf install -y gcc openldap-devel cyrus-sasl-devel openssl-devel && \
               pip install --no-cache-dir -r requirements.txt && \
@@ -90,7 +90,7 @@ jobs:
         run: |
           # Fetch tags to see if this version was already released
           git fetch --tags
-          
+
           if git rev-parse "v${{ env.APP_VERSION }}" >/dev/null 2>&1; then
             echo "::notice title=Release Status::Version v${{ env.APP_VERSION }} already exists. Skipping 'latest' and version tags."
             echo "IS_NEW_RELEASE=false" >> $GITHUB_ENV

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Setup
 
 ```bash
-python3.12 -m venv venv
+python3.14 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt -r requirements-test.txt -r requirements-dev.txt
 pre-commit install --install-hooks
@@ -86,7 +86,7 @@ Tests live in `app/tests/`. `conftest.py` patches `kubernetes_asyncio` and `pyth
 
 ## Deployment
 
-Deploy via Kustomize overlays under `docs/deploy/kustomize/`. The overlay at `overlays/cluster1/` contains the cluster-specific `Secret` with IPA credentials. The app runs in the `openshift-cnv` namespace as UID 1001 on Red Hat UBI 9.
+Deploy via Kustomize overlays under `docs/deploy/kustomize/`. The overlay at `overlays/cluster1/` contains the cluster-specific `Secret` with IPA credentials. The app runs in the `openshift-cnv` namespace as UID 65532 on a Red Hat Hardened Image (`registry.access.redhat.com/hi/python:3.14`).
 
 ## Releasing
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,57 +1,47 @@
-# Stage 1: Builder stage (includes build dependencies like gcc)
-FROM registry.access.redhat.com/ubi10/python-312-minimal:10.1 AS builder
-
-# Switch to root for installing system packages
-USER 0
+# Stage 1: Builder — Red Hat Hardened Python (Hummingbird OS)
+FROM registry.access.redhat.com/hi/python:3.14-builder AS builder
 
 ARG APP_VERSION=0.0.0
-ENV APP_VERSION=$APP_VERSION
+ENV APP_VERSION=$APP_VERSION \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-# Install system dependencies needed for compiling certain Python packages (e.g., python-freeipa)
-RUN microdnf install -y \
-    gcc \
-    openldap-devel \
-    cyrus-sasl-devel \
-    openssl-devel && \
-    microdnf clean all && \
+USER 0
+
+# Native libs that python-freeipa links against at build time.
+RUN dnf install -y \
+        gcc \
+        openldap-devel \
+        cyrus-sasl-devel \
+        openssl-devel && \
+    dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    APP_HOME=/opt/app-root/src
+WORKDIR /app
 
-# Set work directory
-WORKDIR $APP_HOME
+# Build a self-contained venv so the runtime image (which has no package
+# manager and no shell) just needs to COPY a directory.
+RUN python3 -m venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
-# Install Python dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt && \
-    rm -f requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
-# Switch back to non-root user for safety
-USER 1001
+# Stage 2: Runtime — distroless hardened image, no shell, no dnf
+FROM registry.access.redhat.com/hi/python:3.14
 
-FROM registry.access.redhat.com/ubi10/python-312-minimal:10.1
-
-# Copy the installed Python site-packages from the builder
-COPY --from=builder /opt/app-root /opt/app-root
-# Switch to the default non-root user
-USER 1001
-
-# Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    APP_HOME=/opt/app-root/src
+    PATH="/app/.venv/bin:$PATH"
 
-# Set work directory
-WORKDIR $APP_HOME
+WORKDIR /app
 
-# Copy the application code
-COPY app ./app
+COPY --from=builder --chown=65532:65532 /app/.venv /app/.venv
+COPY --chown=65532:65532 app ./app
 
-# Expose port 8443 for secured webhooks
+USER 65532
+
 EXPOSE 8443
 
-# Run Uvicorn with SSL enabled
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8443", "--ssl-keyfile", "/var/run/secrets/serving-cert/tls.key", "--ssl-certfile", "/var/run/secrets/serving-cert/tls.crt"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The application also exposes `/healthz` (liveness), `/readyz` (readiness — add
 * **DNS Auto-Discovery:** Automatically locates FreeIPA servers using _kerberos._tcp SRV records, ensuring high availability and load balancing without manual configuration.
 * **Dynamic OS Support:** Automatically detects OS (RHEL/CentOS/Fedora vs Ubuntu/Debian) based on `instancetype` or `preference` and adjusts install commands (`dnf` vs `apt-get`).
 * **InstanceType Inheritance:** Supports inheriting enrollment labels from `VirtualMachineClusterInstanceType`.
-* **Security:** Runs as a non-root user (UID 1001) on Red Hat UBI 9.
+* **Security:** Runs as a non-root user (UID 65532) on a Red Hat Hardened Image (`hi/python:3.14`).
 * **Observability:** Emits native Kubernetes Events (`Normal` and `Warning`) to the VM object for enrollment status. Exposes a Prometheus `/metrics` endpoint (HTTP request counts, latency, and sizes) and separate `/healthz` (liveness) and `/readyz` (readiness) probes.
 
 ## 🚀 Deployment
@@ -57,7 +57,7 @@ The application also exposes `/healthz` (liveness), `/readyz` (readiness — add
 1. Create a virtual environment:
 
     ```bash
-    python3.12 -m venv venv
+    python3.14 -m venv venv
     source venv/bin/activate
     ```
 


### PR DESCRIPTION
## Summary

- Switch the production container from `registry.access.redhat.com/ubi10/python-312-minimal:10.1` to the Red Hat Hardened Image `registry.access.redhat.com/hi/python:3.14`.
- Upgrade Python 3.12 → 3.14.5 across runtime, CI, and developer docs.
- Container now runs as UID 65532 (was 1001) — the well-known reserved UID for unprivileged services on Red Hat Hardened Images.

## Why

Red Hat Hardened Images (the `hi/` line, marketing page at https://www.redhat.com/en/products/hardened-images) ship with a near-zero CVE baseline at release, a built-in SBOM, applied security profiles, and a swifter CVE remediation cadence than stock UBI. The runtime variant is fully distroless (no shell, no package manager), shrinking the runtime attack surface.

The KubeVirt cloud-init vendor-data work we were tracking (kubevirt/enhancements#150, kubevirt/kubevirt#16156, kubevirt/kubevirt#16278) is stalled — implementation PR was closed without merging, tracking issue auto-closed for staleness on 2026-05-02. Earliest realistic GA would still be ~Q4 2026. So this migration stands on its own rather than waiting on upstream changes.

## What changed

- **Containerfile** rewritten as a two-stage build:
  - Builder (`hi/python:3.14-builder`) installs `gcc`, `openldap-devel`, `cyrus-sasl-devel`, `openssl-devel` (all available in the Hummingbird OS repo) and builds a self-contained venv at `/app/.venv`.
  - Runtime (`hi/python:3.14`) is distroless. It only does `COPY --from=builder` of the venv + app, sets `PATH=/app/.venv/bin:$PATH`, drops to UID 65532, and runs `uvicorn` (already exec-form so no shell needed).
- **pipeline.yaml** unit-test job moved from `ubi9/python-312:latest` to `hi/python:3.14-builder` so CI tests run on the same Python the container ships. `setup-python` bumped to 3.14.
- **integration-tests.yml** `setup-python` bumped to 3.14 in all four jobs.
- **CLAUDE.md** and **README.md** updated for new UID, base image, and Python version.

## Verification

- Built locally: 206 MB image.
- Smoke-tested: image runs as UID 65532, Python 3.14.5, all app modules import cleanly (`app.main`, `app.routers.webhook`, `app.services.ipa`, `app.services.k8s`), uvicorn binary loads.
- `ruff check` clean, `ruff format --check` clean, `pytest` → 40 passed / 39 skipped (integration tests that need a real IPA server/Prometheus correctly skipped in unit-test mode).

## Test plan

- [x] Local build succeeds
- [x] Local lint + pytest pass on hi/python:3.14-builder
- [ ] CI lint job passes
- [ ] CI unit-tests job passes (now runs in `hi/python:3.14-builder`)
- [ ] CI build-test-push job passes (builds + smoke-tests the new Containerfile)
- [ ] CI IPA Lifecycle integration job passes (uses setup-python 3.14)
- [ ] CI Webhook→IPA integration job passes
- [ ] CI Cloud-Init OS matrix passes
- [ ] CI Observability job passes